### PR TITLE
fix wallet_balances api call

### DIFF
--- a/src/gemini.coffee
+++ b/src/gemini.coffee
@@ -125,7 +125,7 @@ module.exports = class Gemini
 
 	wallet_balances: (cb) ->
 
-		@make_request('balances', cb)
+		@make_request('balances', {}, cb)
 
 	new_order: (symbol, amount, price, exchange, side, type, cb) ->
 


### PR DESCRIPTION
Without this I am getting the error:

    TypeError: cb is not a function
        at Request._callback (/Users/pear/projects/gekko/node_modules/gemini-exchange-coffee-api/lib/gemini.js:65:16)
        at Request.self.callback (/Users/pear/projects/gekko/node_modules/gemini-exchange-coffee-api/node_modules/request/request.js:123:22)
        at emitTwo (events.js:125:13)
        at Request.emit (events.js:213:7)
        at Request.<anonymous> (/Users/pear/projects/gekko/node_modules/gemini-exchange-coffee-api/node_modules/request/request.js:893:14)
        at emitOne (events.js:120:20)
        at Request.emit (events.js:210:7)
        at IncomingMessage.<anonymous> (/Users/pear/projects/gekko/node_modules/gemini-exchange-coffee-api/node_modules/request/request.js:844:12)
        at emitNone (events.js:110:20)
        at IncomingMessage.emit (events.js:207:7)